### PR TITLE
Update utxo-fastsync chip to reflect latest changes in BCHN

### DIFF
--- a/specification/utxo-fastsync-chip-20210625.md
+++ b/specification/utxo-fastsync-chip-20210625.md
@@ -101,7 +101,7 @@ The serialized UTXO set is the set of byte sequences constructed by serializing 
 | ? | lockingScript | The locking script ("scriptPubKey", "pk_script"). For token outputs, should include the preamble TOKEN_PREFIX + token data (`0xef`, etc..) | N/A |
 
 ** The Van der Wansem proposal was ambiguous in regard to its definition of the locking script byte count and UTXO height, and it used fixed-width 8-byte integers for the UTXO value.
-This proposal uses a 1-5-byte variable compact-length integer for the UTXO height/isCoinbase flag, and a 1 byte (up to 5) variable compact-length integer for its locking-script byte-count prefix, and a 1-9 byte variable compact-length integer for the utxo value.
+This proposal uses variable compact-length integers in many places to save space within he UTXO format, as well as other places in this specification.
 Considering there are over 55 million UTXOs in the current set, opting to encode all integers as "compact size" ints (little endian) may save hundreds of MB of space. This reduction is not unremarkable and poses little complexity to the format.
 
 ### EC Multiset: Public Key vs Hash
@@ -208,7 +208,7 @@ Peers with incompatible bucket definitions ignore the commitment breakdown after
 The current convention recommends 128 buckets; using a different convention could render snapshots incompatible between implementations.
 
 Each UTXO is placed in its canonical bucket by taking the first 7 bits of the first byte of a single Sha256 hash of the following preimage, and interpreting the resulting bits as an integer index:
-1. the commitment's prvcious block hash**, as little endian
+1. the commitment's previous block hash**, as little endian
 2. the UTXO's transaction hash, as little endian
 3. the UTXO's output index, as a 4-byte integer, little endian
 

--- a/specification/utxo-fastsync-chip-20210625.md
+++ b/specification/utxo-fastsync-chip-20210625.md
@@ -101,8 +101,8 @@ The serialized UTXO set is the set of byte sequences constructed by serializing 
 | ? | lockingScript | The locking script ("scriptPubKey", "pk_script"). For token outputs, should include the preamble TOKEN_PREFIX + token data (`0xef`, etc..) | N/A |
 
 ** The Van der Wansem proposal was ambiguous in regard to its definition of the locking script byte count and UTXO height, and it used fixed-width 8-byte integers for the UTXO value.
-This proposal uses variable [compact variable-length integers](https://documentation.cash/protocol/formats/variable-length-integer) also known as `CompactSzie` in many places to save space within he UTXO format, as well as other places in this specification.
-Considering there are over 55 million UTXOs in the current set, opting to encode all integers as `CompactSize` ints (little endian) may save hundreds of MB of space. This reduction is not unremarkable and poses little complexity to the format.
+This proposal uses variable [compact variable-length integers](https://documentation.cash/protocol/formats/variable-length-integer) also known as `CompactSize` in many places to save space within the UTXO format, as well as other places in this specification.
+Considering there are over 55 million UTXOs in the current set, opting to encode some integers as `CompactSize` ints (little endian) may save hundreds of MB of space. This reduction is not unremarkable and poses little complexity to the format.
 
 **Note:** *All* `CompactSize` integers appearing in this specification **must** be "minimally encoded". If they are not, software **must** reject any messages or data featuring non-minimally-encoded compact sizes.
 

--- a/specification/utxo-fastsync-chip-20210625.md
+++ b/specification/utxo-fastsync-chip-20210625.md
@@ -95,7 +95,7 @@ The serialized UTXO set is the set of byte sequences constructed by serializing 
 | --- | --- | --- | --- |
 | 32 | transactionHash | The hash ("txid") of the transaction. | Little |
 | 1-5 | outputIndex | The index of the output within the transaction (as a compact variable length integer**). | Little |
-| 1-5 | height, isCoinbase | This is serialized as a compact variable length integer**. The least significant bit is set if the UTXO is a coinbase output.  The remaining high-order 31 bits** represent the block height. | Little |
+| 1-5 | height, isCoinbase | This is serialized as a compact variable length integer**. The least significant bit is set if the UTXO is a coinbase output.  The remaining high-order 31 bits represent the block height. | Little |
 | 1-9 | value | The amount, in satoshis (as a compact variable length integer**). | Little |
 | 1-5 | lockingScriptByteCount | The number of bytes in the locking script (as a compact variable length integer**). | Little |
 | ? | lockingScript | The locking script ("scriptPubKey", "pk_script"). For token outputs, should include the preamble TOKEN_PREFIX + token data (`0xef`, etc..) | N/A |

--- a/specification/utxo-fastsync-chip-20210625.md
+++ b/specification/utxo-fastsync-chip-20210625.md
@@ -293,7 +293,7 @@ Provides a variable sized collection of UTXO snapshot metadata that the node has
 | Field Name | Byte Count | Format | Description |
 | --- | --- | --- | --- |
 | block hash | 32 | sha256 hash, little endian | The block hash associated with this UTXO snapshot. |
-| block height | 1-5 | integer, little endian, compact variable-length | The block height associated with this UTXO snapshot. |
+| block height | 4 | integer, little endian, unsigned | The block height associated with this UTXO snapshot. |
 | public key | 33 | public key, big endian | The secp256k1 point of the EC multiset for this UTXO snapshot. |
 | byte count | 1-9 | integer, little endian, compact variable-length | The total number of bytes within the utxo snapshot. |
 | utxo bucket (x128) | ? | <ins>Snapshot Bucket Metadata</ins> | The bucket breakdown for this snapshot.  There are always 128 buckets per snapshot. |

--- a/specification/utxo-fastsync-chip-20210625.md
+++ b/specification/utxo-fastsync-chip-20210625.md
@@ -95,14 +95,16 @@ The serialized UTXO set is the set of byte sequences constructed by serializing 
 | --- | --- | --- | --- |
 | 32 | transactionHash | The hash ("txid") of the transaction. | Little |
 | 1-5 | outputIndex | The index of the output within the transaction (as a compact variable length integer**). | Little |
-| 1-5 | height, isCoinbase | This is serialized as a compact variable length integer**. The least significant bit is set if the UTXO is a coinbase output.  The remaining high-order 31 bits represent the block height. | Little |
+| 4 | height, isCoinbase | This is serialized as an unsigned 32-bit integer. The least significant bit is set if the UTXO is a coinbase output.  The remaining high-order 31 bits represent the block height (shifted over by 1 bit). | Little |
 | 1-9 | value | The amount, in satoshis, negative values are disallowed, so the useful range is 0 - 2^63-1. Serialized as a compact variable length integer**. | Little |
 | 1-5 | lockingScriptByteCount | The number of bytes in the locking script (as a compact variable length integer**). | Little |
 | ? | lockingScript | The locking script ("scriptPubKey", "pk_script"). For token outputs, should include the preamble TOKEN_PREFIX + token data (`0xef`, etc..) | N/A |
 
 ** The Van der Wansem proposal was ambiguous in regard to its definition of the locking script byte count and UTXO height, and it used fixed-width 8-byte integers for the UTXO value.
-This proposal uses variable compact-length integers in many places to save space within he UTXO format, as well as other places in this specification.
-Considering there are over 55 million UTXOs in the current set, opting to encode all integers as "compact size" ints (little endian) may save hundreds of MB of space. This reduction is not unremarkable and poses little complexity to the format.
+This proposal uses variable [compact variable-length integers](https://documentation.cash/protocol/formats/variable-length-integer) also known as `CompactSzie` in many places to save space within he UTXO format, as well as other places in this specification.
+Considering there are over 55 million UTXOs in the current set, opting to encode all integers as `CompactSize` ints (little endian) may save hundreds of MB of space. This reduction is not unremarkable and poses little complexity to the format.
+
+**Note:** *All* `CompactSize` integers appearing in this specification **must** be "minimally encoded". If they are not, software **must** reject any messages or data featuring non-minimally-encoded compact sizes.
 
 ### EC Multiset: Public Key vs Hash
 

--- a/specification/utxo-fastsync-chip-20210625.md
+++ b/specification/utxo-fastsync-chip-20210625.md
@@ -104,10 +104,6 @@ The serialized UTXO set is the set of byte sequences constructed by serializing 
 This proposal uses a 1-5-byte variable compact-length integer for the UTXO height/isCoinbase flag, and a 1 byte (up to 5) variable compact-length integer for its locking-script byte-count prefix, and a 1-9 byte variable compact-length integer for the utxo value.
 Considering there are over 55 million UTXOs in the current set, opting to encode all integers as "compact size" ints (little endian) may save hundreds of MB of space. This reduction is not unremarkable and poses little complexity to the format.
 
-DISCUSSION: the above reasoning regarding choosing a compact variable length integer format vs 4-byte integer format for the lockingScriptByteCount could apply to outputIndex.
-However, there is a well-established convention for outputIndex as being defined as a 4-byte integer.
-The community should discuss if going against current convention and redefining the outputIndex for UTXO commitments is worth the 160+ MB gain in space-efficiency.
-
 ### EC Multiset: Public Key vs Hash
 
 A UTXO commitment/snapshot is identified by its EC Multiset's public key; this is distinct from Van der Wansem's proposal.

--- a/specification/utxo-fastsync-chip-20210625.md
+++ b/specification/utxo-fastsync-chip-20210625.md
@@ -97,11 +97,11 @@ The serialized UTXO set is the set of byte sequences constructed by serializing 
 | 1-5 | outputIndex | The index of the output within the transaction (as a compact variable length integer**). | Little |
 | 1-5 | height, isCoinbase | This is serialized as a compact variable length integer**. The least significant bit is set if the UTXO is a coinbase output.  The remaining high-order 31 bits** represent the block height. | Little |
 | 1-9 | value | The amount, in satoshis (as a compact variable length integer**). | Little |
-| 1-4 | lockingScriptByteCount | The number of bytes in the locking script (as a compact variable length integer**). | Little |
-| ? | lockingScript | The locking script ("scriptPubKey", "pk_script"). | N/A |
+| 1-5 | lockingScriptByteCount | The number of bytes in the locking script (as a compact variable length integer**). | Little |
+| ? | lockingScript | The locking script ("scriptPubKey", "pk_script"). For token outputs, should include the preamble TOKEN_PREFIX + token data (`0xef`, etc..) | N/A |
 
 ** The Van der Wansem proposal was ambiguous in regard to its definition of the locking script byte count and UTXO height, and it used fixed-width 8-byte integers for the UTXO value.
-This proposal uses a 1-5-byte variable compact-length integer for the UTXO height/isCoinbase flag, and a 1 byte (up to 4) variable compact-length integer for its locking-script byte-count prefix, and a 1-9 byte variable compact-length integer for the utxo value.
+This proposal uses a 1-5-byte variable compact-length integer for the UTXO height/isCoinbase flag, and a 1 byte (up to 5) variable compact-length integer for its locking-script byte-count prefix, and a 1-9 byte variable compact-length integer for the utxo value.
 Considering there are over 55 million UTXOs in the current set, opting to encode all integers as "compact size" ints (little endian) may save hundreds of MB of space. This reduction is not unremarkable and poses little complexity to the format.
 
 DISCUSSION: the above reasoning regarding choosing a compact variable length integer format vs 4-byte integer format for the lockingScriptByteCount could apply to outputIndex.

--- a/specification/utxo-fastsync-chip-20210625.md
+++ b/specification/utxo-fastsync-chip-20210625.md
@@ -96,7 +96,7 @@ The serialized UTXO set is the set of byte sequences constructed by serializing 
 | 32 | transactionHash | The hash ("txid") of the transaction. | Little |
 | 1-5 | outputIndex | The index of the output within the transaction (as a compact variable length integer**). | Little |
 | 1-5 | height, isCoinbase | This is serialized as a compact variable length integer**. The least significant bit is set if the UTXO is a coinbase output.  The remaining high-order 31 bits represent the block height. | Little |
-| 1-9 | value | The amount, in satoshis (as a compact variable length integer**). | Little |
+| 1-9 | value | The amount, in satoshis, negative values are disallowed, so the useful range is 0 - 2^63-1. Serialized as a compact variable length integer**. | Little |
 | 1-5 | lockingScriptByteCount | The number of bytes in the locking script (as a compact variable length integer**). | Little |
 | ? | lockingScript | The locking script ("scriptPubKey", "pk_script"). For token outputs, should include the preamble TOKEN_PREFIX + token data (`0xef`, etc..) | N/A |
 


### PR DESCRIPTION
- Use compact size variable-length integers in as many places as possible in the message(s).  UTXO `value` and all other things such as `byteCount` should all be encoding compact size integers to save space.
- Mention that locking_script should include the "token data" (token prefix `0xef...` preamble).
- The bucket index should be calculated from "previous block hash" (rather than commitment block hash) as we discussed in slack and in Google meet. I think this is more natural and more "future proof".
- As previously discussed, we can/should swap the bit for `isCoinbase` to the lowest-order bit, rather than the highest order. This makes "height" be the high-order 31-bits.  This also makes it easier and more efficient to use compactsize var-length integers for this field!

I have made these changes in my branch in BCHN already and am in the process of testing them.  Overall they should lead to a more efficient encoding.